### PR TITLE
Feature/remove exit 3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-04-09  Tle Ekkul  <e.aryuth@gmail.com>
+ Changed: Not exit with status code 3 when no jobs anymore
+
 [[RELEASED 3.1]]
 
 2019-04-09  Tle Ekkul  <e.aryuth@gmail.com>

--- a/mod_ngarn/worker.py
+++ b/mod_ngarn/worker.py
@@ -135,6 +135,4 @@ class JobRunner:
                     log.info(f"Executing#{job_number}: \t{job.id}")
                     result = await job.execute()
                     log.info(f"Executed#{job_number}: \t{result}")
-                else:
-                    sys.exit(3)
         await cnx.close()

--- a/mod_ngarn/worker.py
+++ b/mod_ngarn/worker.py
@@ -135,4 +135,6 @@ class JobRunner:
                     log.info(f"Executing#{job_number}: \t{job.id}")
                     result = await job.execute()
                     log.info(f"Executed#{job_number}: \t{result}")
+                else:
+                    break
         await cnx.close()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -319,22 +319,3 @@ class TestExitFromJobRunner(TestCase):
             loop.run_until_complete(future)
 
         return wrapper
-
-    @async_test
-    async def test_job_runner_should_return_exit_code_if_no_more_job(self):
-        queue_table = "public.modngarn_job"
-        await create_table(queue_table)
-        cnx = await get_connection()
-        await cnx.execute(f"TRUNCATE TABLE {queue_table};")
-        await cnx.execute(
-            """
-        INSERT INTO {queue_table} (id, fn_name, args, reason) VALUES ('job-1', 'tests.test_job.async_dummy_job', '["hello"]', 'some error message')
-        """.format(
-                queue_table=queue_table
-            )
-        )
-        job_runner = JobRunner()
-        with self.assertRaises(SystemExit) as exit:
-            await job_runner.run(queue_table, 2, None)
-
-        self.assertEqual(exit.exception.code, 3)


### PR DESCRIPTION
We don't want sys.exit(3) anymore because we are going to use `mod-ngarn wait-for-notify` instead.